### PR TITLE
Call superclass in postCreate

### DIFF
--- a/builder-2d/widgets/MyWidget/setting/Setting.ts
+++ b/builder-2d/widgets/MyWidget/setting/Setting.ts
@@ -22,7 +22,8 @@ class Setting {
   baseClass = 'my-widget-setting';
 
   postCreate(args: any) {
-    //the config object is passed in
+    let self: any = this;
+    self.inherited(arguments);
     this.setConfig(this.config);
   };
 


### PR DESCRIPTION
#13 
Also removed comment because this.config is set in the object by the WAB framework before postCreate is called; it's not passed in via args.